### PR TITLE
Update to xbee-api 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ramda": "^0.22",
     "rx": "^4.1",
     "serialport": "^4.0",
-    "xbee-api": "^0.4"
+    "xbee-api": "^0.5.1"
   },
   "devDependencies": {
     "grunt": "^1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,9 +449,9 @@ glob@^4.3.5:
     minimatch "^2.0.1"
     once "^1.3.0"
 
-glob@^7.0.5, glob@~7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+glob@^7.0.5, glob@~7.0.0:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.6.tgz#211bafaf49e525b8cd93260d14ab136152b3f57a"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -470,9 +470,9 @@ glob@~5.0.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@~7.0.0:
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.6.tgz#211bafaf49e525b8cd93260d14ab136152b3f57a"
+glob@~7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1262,6 +1262,10 @@ rx@^4.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
+safe-buffer@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
 "semver@2 || 3 || 4 || 5", semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
@@ -1531,12 +1535,13 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-xbee-api@^0.4:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/xbee-api/-/xbee-api-0.4.6.tgz#a09830177b1e9a4bed85f8505c48b13198d105c2"
+xbee-api@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/xbee-api/-/xbee-api-0.5.1.tgz#d3b9b5ce18703af1ace35b3c30aac3a8c3dd6416"
   dependencies:
     buffer-builder "^0.2.0"
     buffer-reader "https://github.com/prodatakey/node-buffer-reader/archive/v0.0.3.tar.gz"
+    safe-buffer "~5.0.1"
 
 xtend@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
This is required for compatibility with older Node.js versions as `xbee-api` v0.4.6 uses the new Buffer API added in Node v5.x.

This is a heads up pull request and will be released as v2.1.0.