### PR TITLE
add broadcast support

### DIFF
--- a/lib/xbee-rx.js
+++ b/lib/xbee-rx.js
@@ -151,7 +151,7 @@ module.exports = function xbeeRxLibrary(options) {
         return _sendFrameStreamResponse(frame, timeoutMs, xbee_api.constants.FRAME_TYPE.AT_COMMAND_RESPONSE)
             .map(function (frame) {
                 if (frame.commandStatus === xbee_api.constants.COMMAND_STATUS.OK) {
-                    return frame;
+                    return frame.commandData;
                 }
 
                 // if not OK, throw error
@@ -202,6 +202,9 @@ module.exports = function xbeeRxLibrary(options) {
     // on success or end in an Error with the failed status as the text.
     // Only one of destination64 or destination16 should be given; the
     // other should be undefined.
+    // For a broadcast, both destination64 and destination16 should be
+    // undefined. Also, in that case the entire frames are emitted and not
+    // just the command data, so that the sender's address is preserved.
     function _remoteCommand(command, destination64, destination16, timeoutMs, commandParameter, broadcast) {
         var frame = {
                 type: xbee_api.constants.FRAME_TYPE.REMOTE_AT_COMMAND_REQUEST,
@@ -218,7 +221,9 @@ module.exports = function xbeeRxLibrary(options) {
         return _sendFrameStreamResponse(frame, timeoutMs, xbee_api.constants.FRAME_TYPE.REMOTE_COMMAND_RESPONSE, broadcast)
             .map(function (frame) {
                 if (frame.commandStatus === xbee_api.constants.COMMAND_STATUS.OK) {
-                    return frame;
+                    // for broadcast responses the sender's address should be returned as well
+                    if (broadcast) return frame;
+                    return frame.commandData;
                 }
 
                 // if not OK, throw error
@@ -231,6 +236,8 @@ module.exports = function xbeeRxLibrary(options) {
     // returned that will complete on success or end in an Error with the
     // failed status as the text.  Only one of destination64 or
     // destination16 should be given; the other should be undefined.
+    // For a broadcast, both destination64 and destination16 should be
+    // undefined.
     function _remoteTransmit(destination64, destination16, data, timeoutMs, broadcast=false) {
         var frame = {
                 data: data,

--- a/lib/xbee-rx.js
+++ b/lib/xbee-rx.js
@@ -41,7 +41,8 @@ var remoteCommandOptionsSpec = {
     destinationId: { type$: [ 'string' ] },
     destination64: { type$: [ 'string', 'array' ] },
     destination16: { type$: [ 'string', 'array' ] },
-    timeoutMs: { type$: 'integer', min$: 10 }
+    timeoutMs: { type$: 'integer', min$: 10 },
+    broadcast: 'boolean$'
 };
 
 
@@ -51,7 +52,8 @@ var remoteTransmitOptionsSpec = {
     destinationId: { type$: [ 'string' ] },
     destination64: { type$: [ 'string', 'array' ] },
     destination16: { type$: [ 'string', 'array' ] },
-    timeoutMs: { type$: 'integer', min$: 10 }
+    timeoutMs: { type$: 'integer', min$: 10 },
+    broadcast: 'boolean$'
 };
 
 
@@ -99,7 +101,7 @@ module.exports = function xbeeRxLibrary(options) {
     // Returns a stream that will (when subscribed to) send the given frame and
     // emit the response frame(s) (or error with a timeout).
     // A broadcast can result in more than one response frame.
-    function _sendFrameStreamResponse(frame, timeoutMs, responseFrameType) {
+    function _sendFrameStreamResponse(frame, timeoutMs, responseFrameType, broadcast=false) {
         var frameId = xbeeAPI.nextFrameId(),
             sendStream,
             resultStream;
@@ -110,6 +112,7 @@ module.exports = function xbeeRxLibrary(options) {
         // Results are the frames matching the frame ID and response type
         resultStream = frameSource
             .where(_createFilter(frameId, responseFrameType));
+        if (!broadcast) resultStream = resultStream.take(1);
 
         sendStream = rx.Observable.create(function (observer) {
             if (debug) {
@@ -128,10 +131,11 @@ module.exports = function xbeeRxLibrary(options) {
             }
         });
 
-        // Return our result stream with a timeout
-        return rx.Observable
-            .merge(sendStream, resultStream)
-            .timeout(timeoutMs, rx.Observable.throw(new Error("Timed out after " + timeoutMs + " ms")));
+        // Return our result stream with a timeout (if not a broadcast)
+        var result = rx.Observable
+            .merge(sendStream, resultStream);
+        if (!broadcast) result = result.timeout(timeoutMs, rx.Observable.throw(new Error("Timed out after " + timeoutMs + " ms")));
+        return result;
     }
 
 
@@ -200,7 +204,7 @@ module.exports = function xbeeRxLibrary(options) {
     // on success or end in an Error with the failed status as the text.
     // Only one of destination64 or destination16 should be given; the
     // other should be undefined.
-    function _remoteCommand(command, destination64, destination16, timeoutMs, commandParameter) {
+    function _remoteCommand(command, destination64, destination16, timeoutMs, commandParameter, broadcast) {
         var frame = {
                 type: xbee_api.constants.FRAME_TYPE.REMOTE_AT_COMMAND_REQUEST,
                 command: command,
@@ -213,7 +217,7 @@ module.exports = function xbeeRxLibrary(options) {
             console.log("Sending", command, "to", destination64, "with parameter", commandParameter || []);
         }
 
-        return _sendFrameStreamResponse(frame, timeoutMs, xbee_api.constants.FRAME_TYPE.REMOTE_COMMAND_RESPONSE)
+        return _sendFrameStreamResponse(frame, timeoutMs, xbee_api.constants.FRAME_TYPE.REMOTE_COMMAND_RESPONSE, broadcast)
             .map(function (frame) {
                 if (frame.commandStatus === xbee_api.constants.COMMAND_STATUS.OK) {
                     return frame;
@@ -229,7 +233,7 @@ module.exports = function xbeeRxLibrary(options) {
     // returned that will complete on success or end in an Error with the
     // failed status as the text.  Only one of destination64 or
     // destination16 should be given; the other should be undefined.
-    function _remoteTransmit(destination64, destination16, data, timeoutMs) {
+    function _remoteTransmit(destination64, destination16, data, timeoutMs, broadcast=false) {
         var frame = {
                 data: data,
                 type: xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_REQUEST,
@@ -249,7 +253,7 @@ module.exports = function xbeeRxLibrary(options) {
             console.log("Sending '" + data + "' to", destination64 || destination16);
         }
 
-        return _sendFrameStreamResponse(frame, timeoutMs, responseFrameType)
+        return _sendFrameStreamResponse(frame, timeoutMs, responseFrameType, broadcast)
             .flatMap(function (frame) {
                 if (frame.deliveryStatus === xbee_api.constants.DELIVERY_STATUS.SUCCESS) {
                     return rx.Observable.empty();
@@ -362,13 +366,15 @@ module.exports = function xbeeRxLibrary(options) {
         commandParameter = settings.commandParameter || [];
 
         if (settings.destination64 || settings.destination16) {
-            return _remoteCommand(command, settings.destination64, settings.destination16, timeoutMs, commandParameter);
+            return _remoteCommand(command, settings.destination64, settings.destination16, timeoutMs,
+                commandParameter, settings.broadcast);
         }
 
         if (settings.destinationId) {
             return _lookupByNodeIdentifier(settings.destinationId, timeoutMs)
                 .flatMap(function (lookupResult) {
-                    return _remoteCommand(command, lookupResult, undefined, timeoutMs, commandParameter);
+                    return _remoteCommand(command, lookupResult, undefined, timeoutMs, commandParameter,
+                        settings.broadcast);
                 });
         }
     }
@@ -401,13 +407,13 @@ module.exports = function xbeeRxLibrary(options) {
         data = settings.data;
 
         if (settings.destination64 || settings.destination16) {
-            return _remoteTransmit(settings.destination64, settings.destination16, data, timeoutMs);
+            return _remoteTransmit(settings.destination64, settings.destination16, data, timeoutMs, settings.broadcast);
         }
 
         if (settings.destinationId) {
             return _lookupByNodeIdentifier(settings.destinationId, timeoutMs)
                 .flatMap(function (lookupResult) {
-                    return _remoteTransmit(lookupResult, undefined, data, timeoutMs);
+                    return _remoteTransmit(lookupResult, undefined, data, timeoutMs, settings.broadcast);
                 });
         }
     }

--- a/lib/xbee-rx.js
+++ b/lib/xbee-rx.js
@@ -37,7 +37,6 @@ var localCommandOptionsSpec = {
 var remoteCommandOptionsSpec = {
     command: 'required$, string$',
     commandParameter: { type$: [ 'string', 'array' ] },
-    exactlyone$: [ 'destinationId', 'destination64', 'destination16' ],
     destinationId: { type$: [ 'string' ] },
     destination64: { type$: [ 'string', 'array' ] },
     destination16: { type$: [ 'string', 'array' ] },
@@ -48,7 +47,6 @@ var remoteCommandOptionsSpec = {
 
 var remoteTransmitOptionsSpec = {
     data: 'required$, string$',
-    exactlyone$: [ 'destinationId', 'destination64', 'destination16' ],
     destinationId: { type$: [ 'string' ] },
     destination64: { type$: [ 'string', 'array' ] },
     destination16: { type$: [ 'string', 'array' ] },

--- a/lib/xbee-rx.js
+++ b/lib/xbee-rx.js
@@ -110,7 +110,11 @@ module.exports = function xbeeRxLibrary(options) {
         // Results are the frames matching the frame ID and response type
         resultStream = frameSource
             .where(_createFilter(frameId, responseFrameType));
-        if (!broadcast) resultStream = resultStream.take(1);
+        if (!broadcast) {
+            resultStream = resultStream.take(1);
+        } else {
+            setTimeout(function() { resultStream.close() }, timeoutMs);
+        }
 
         sendStream = rx.Observable.create(function (observer) {
             if (debug) {

--- a/lib/xbee-rx.js
+++ b/lib/xbee-rx.js
@@ -37,7 +37,6 @@ var localCommandOptionsSpec = {
 var remoteCommandOptionsSpec = {
     command: 'required$, string$',
     commandParameter: { type$: [ 'string', 'array' ] },
-    exactlyone$: [ 'destinationId', 'destination64', 'destination16' ],
     destinationId: { type$: [ 'string' ] },
     destination64: { type$: [ 'string', 'array' ] },
     destination16: { type$: [ 'string', 'array' ] },
@@ -48,7 +47,6 @@ var remoteCommandOptionsSpec = {
 
 var remoteTransmitOptionsSpec = {
     data: 'required$, string$',
-    exactlyone$: [ 'destinationId', 'destination64', 'destination16' ],
     destinationId: { type$: [ 'string' ] },
     destination64: { type$: [ 'string', 'array' ] },
     destination16: { type$: [ 'string', 'array' ] },
@@ -365,7 +363,7 @@ module.exports = function xbeeRxLibrary(options) {
 
         commandParameter = settings.commandParameter || [];
 
-        if (settings.destination64 || settings.destination16) {
+        if (settings.broadcast || settings.destination16 || settings.destination64) {
             return _remoteCommand(command, settings.destination64, settings.destination16, timeoutMs,
                 commandParameter, settings.broadcast);
         }
@@ -406,7 +404,7 @@ module.exports = function xbeeRxLibrary(options) {
 
         data = settings.data;
 
-        if (settings.destination64 || settings.destination16) {
+        if (settings.broadcast || settings.destination16 || settings.destination64) {
             return _remoteTransmit(settings.destination64, settings.destination16, data, timeoutMs, settings.broadcast);
         }
 

--- a/lib/xbee-rx.js
+++ b/lib/xbee-rx.js
@@ -149,7 +149,7 @@ module.exports = function xbeeRxLibrary(options) {
         return _sendFrameStreamResponse(frame, timeoutMs, xbee_api.constants.FRAME_TYPE.AT_COMMAND_RESPONSE)
             .map(function (frame) {
                 if (frame.commandStatus === xbee_api.constants.COMMAND_STATUS.OK) {
-                    return frame.commandData;
+                    return frame;
                 }
 
                 // if not OK, throw error
@@ -216,7 +216,7 @@ module.exports = function xbeeRxLibrary(options) {
         return _sendFrameStreamResponse(frame, timeoutMs, xbee_api.constants.FRAME_TYPE.REMOTE_COMMAND_RESPONSE)
             .map(function (frame) {
                 if (frame.commandStatus === xbee_api.constants.COMMAND_STATUS.OK) {
-                    return frame.commandData;
+                    return frame;
                 }
 
                 // if not OK, throw error

--- a/lib/xbee-rx.js
+++ b/lib/xbee-rx.js
@@ -97,7 +97,8 @@ module.exports = function xbeeRxLibrary(options) {
 
 
     // Returns a stream that will (when subscribed to) send the given frame and
-    // emit the response frame (or error with a timeout).
+    // emit the response frame(s) (or error with a timeout).
+    // A broadcast can result in more than one response frame.
     function _sendFrameStreamResponse(frame, timeoutMs, responseFrameType) {
         var frameId = xbeeAPI.nextFrameId(),
             sendStream,
@@ -106,10 +107,9 @@ module.exports = function xbeeRxLibrary(options) {
         // Set the frame ID and create the callback to check for it
         frame.id = frameId;
 
-        // Result is the first frame that matches the frame ID and response type
+        // Results are the frames matching the frame ID and response type
         resultStream = frameSource
-            .where(_createFilter(frameId, responseFrameType))
-            .take(1);
+            .where(_createFilter(frameId, responseFrameType));
 
         sendStream = rx.Observable.create(function (observer) {
             if (debug) {


### PR DESCRIPTION
xbee-api allows broadcasts (destination16 and destination64 are set correctly for broadcast by default).

I added a `broadcast` flag to the `remote*()` methods. The response observable is held open for the duratio n of `timeoutMs` and all matching responses in that time are served. Serving `commandData` is not enough in that case, as the sender address is likely important. Thus, for broadcasts, the whole frame is returned. This is a bit messy, but I didn't want to break any existing pieces.