### PR TITLE
Add broadcast flag for remote transmit and remote commands

### DIFF
--- a/examples/simple-remote.js
+++ b/examples/simple-remote.js
@@ -30,7 +30,7 @@ var commandParameter = (process.argv && process.argv[4]) || [];
 
 if (!destinationId || process.argv[5]) {
     console.error("Usage:");
-    console.error(process.argv.slice(0, 2).join(" ") + " <destination ID> [<command>]");
+    console.error(process.argv.slice(0, 2).join(" ") + " <destination ID or *> [<command>]");
     process.exit(1);
 }
 
@@ -47,7 +47,8 @@ xbee
     .remoteCommand({
         command: command,
         commandParameter: commandParameter,
-        destinationId: destinationId
+        destinationId: destinationId !== "*" ? destinationId : undefined,
+        broadcast: destinationId === "*"
     })
     .subscribe(function (resultBuffer) {
         var resultAsInt,

--- a/examples/simple-transmit.js
+++ b/examples/simple-transmit.js
@@ -29,13 +29,14 @@ var data = process.argv && process.argv[3];
 
 if (!data || process.argv[4]) {
     console.error("Usage:");
-    console.error(process.argv.slice(0, 2).join(" ") + " <destination ID> <data>");
+    console.error(process.argv.slice(0, 2).join(" ") + " <destination ID or *> <data>");
     process.exit(1);
 }
 
 xbee
     .remoteTransmit({
-        destinationId: destinationId,
+        destinationId: destinationId !== "*" ? destinationId : undefined,
+        broadcast: destinationId === "*",
         data: data
     })
     .subscribe(function () {

--- a/lib/xbee-rx.js
+++ b/lib/xbee-rx.js
@@ -35,9 +35,9 @@ var localCommandOptionsSpec = {
 
 
 var remoteCommandOptionsSpec = {
+    broadcast: "boolean$",
     command: "required$, string$",
     commandParameter: { type$: [ "string", "array" ] },
-    exactlyone$: [ "destinationId", "destination64", "destination16" ],
     destinationId: { type$: [ "string" ] },
     destination64: { type$: [ "string", "array" ] },
     destination16: { type$: [ "string", "array" ] },
@@ -46,8 +46,8 @@ var remoteCommandOptionsSpec = {
 
 
 var remoteTransmitOptionsSpec = {
+    broadcast: "boolean$",
     data: "required$, string$",
-    exactlyone$: [ "destinationId", "destination64", "destination16" ],
     destinationId: { type$: [ "string" ] },
     destination64: { type$: [ "string", "array" ] },
     destination16: { type$: [ "string", "array" ] },
@@ -109,7 +109,7 @@ module.exports = function xbeeRxLibrary(options) {
         // Result is the first frame that matches the frame ID and response type
         resultStream = frameSource
             .where(_createFilter(frameId, responseFrameType))
-            .take(1);
+            .takeUntil(rx.Observable.timer(timeoutMs));
 
         sendStream = rx.Observable.create(function (observer) {
             if (debug) {
@@ -154,7 +154,8 @@ module.exports = function xbeeRxLibrary(options) {
 
                 // if not OK, throw error
                 throw new Error(xbee_api.constants.COMMAND_STATUS[frame.commandStatus]);
-            });
+            })
+            .take(1);
     }
 
 
@@ -178,7 +179,7 @@ module.exports = function xbeeRxLibrary(options) {
     function _lookupByNodeIdentifier(nodeIdentifier, timeoutMs) {
         // if the address is cached, return that
         if (cachedNodes[nodeIdentifier]) {
-            return rx.Observable.return(cachedNodes[nodeIdentifier]);
+            return rx.Observable.return({ destination64: cachedNodes[nodeIdentifier]});
         }
 
         if (debug) {
@@ -191,72 +192,9 @@ module.exports = function xbeeRxLibrary(options) {
             .do(function (address64) {
                 // cache the address
                 cachedNodes[nodeIdentifier] = address64;
-            });
-    }
-
-
-    // Sends a the given command and parameter to the given destination.
-    // A stream is returned that will emit to the resulting command data
-    // on success or end in an Error with the failed status as the text.
-    // Only one of destination64 or destination16 should be given; the
-    // other should be undefined.
-    function _remoteCommand(command, destination64, destination16, timeoutMs, commandParameter) {
-        var frame = {
-                type: xbee_api.constants.FRAME_TYPE.REMOTE_AT_COMMAND_REQUEST,
-                command: command,
-                commandParameter: commandParameter,
-                destination64: destination64,
-                destination16: destination16
-            };
-
-        if (debug) {
-            console.log("Sending", command, "to", destination64, "with parameter", commandParameter || []);
-        }
-
-        return _sendFrameStreamResponse(frame, timeoutMs, xbee_api.constants.FRAME_TYPE.REMOTE_COMMAND_RESPONSE)
-            .map(function (frame) {
-                if (frame.commandStatus === xbee_api.constants.COMMAND_STATUS.OK) {
-                    return frame.commandData;
-                }
-
-                // if not OK, throw error
-                throw new Error(xbee_api.constants.COMMAND_STATUS[frame.commandStatus]);
-            });
-    }
-
-
-    // Sends a the given data to the given destination.  A stream is
-    // returned that will complete on success or end in an Error with the
-    // failed status as the text.  Only one of destination64 or
-    // destination16 should be given; the other should be undefined.
-    function _remoteTransmit(destination64, destination16, data, timeoutMs) {
-        var frame = {
-                data: data,
-                type: xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_REQUEST,
-                destination64: destination64,
-                destination16: destination16
-            },
-            responseFrameType = xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS;
-
-        if (module === "802.15.4") {
-            responseFrameType = xbee_api.constants.FRAME_TYPE.TX_STATUS;
-            frame.type = destination64 ?
-                    xbee_api.constants.FRAME_TYPE.TX_REQUEST_64 :
-                    xbee_api.constants.FRAME_TYPE.TX_REQUEST_16;
-        }
-
-        if (debug) {
-            console.log("Sending '" + data + "' to", destination64 || destination16);
-        }
-
-        return _sendFrameStreamResponse(frame, timeoutMs, responseFrameType)
-            .flatMap(function (frame) {
-                if (frame.deliveryStatus === xbee_api.constants.DELIVERY_STATUS.SUCCESS) {
-                    return rx.Observable.empty();
-                }
-
-                // if not OK, throw error
-                return rx.Observable.throw(new Error(xbee_api.constants.DELIVERY_STATUS[frame.deliveryStatus]));
+            })
+            .map(function (address64) {
+                return { destination64: address64 };
             });
     }
 
@@ -268,8 +206,28 @@ module.exports = function xbeeRxLibrary(options) {
     // length, if it exists, destination16 is the correct length, if it
     // exists, and destinationId was used only if the module type was
     // not '802.15.4'.
-    function _validateDestination(settings) {
-        var hexRegex = /^[0-9a-f]+$/;
+    function _generateDestination(settings, timeoutMs) {
+        var hexRegex = /^[0-9a-f]+$/,
+            destinationFlagsCount = (settings.broadcast ? 1 : 0) +
+                (settings.destinationId ? 1 : 0) +
+                (settings.destination16 ? 1 : 0) +
+                (settings.destination64 ? 1 : 0);
+
+        if (destinationFlagsCount === 0) {
+            if (module === "802.15.4") {
+                throw new Error("'destination16', 'destination64', or 'broadcast = true' must be specified.");
+            }
+
+            throw new Error("'destinationId', 'destination16', 'destination64', or 'broadcast = true' must be specified.");
+        }
+
+        if (destinationFlagsCount > 1) {
+            if (module === "802.15.4") {
+                throw new Error("Only one of 'destination16', 'destination64', or 'broadcast = true' may be specified.");
+            }
+
+            throw new Error("Only one of 'destinationId', 'destination16', 'destination64', or 'broadcast = true' may be specified.");
+        }
 
         if (settings.destinationId && module === "802.15.4") {
             throw new Error("'destinationId' is not supported by 802.15.4 modules. Use 'destination16' or 'destination64' instead.");
@@ -309,6 +267,97 @@ module.exports = function xbeeRxLibrary(options) {
                     throw new Error("'destination16' is not a byte array. It must be a hex string of length 4 or a byte array of length 2.");
                 }
             });
+        }
+
+        if (settings.broadcast) {
+            return rx.Observable.return({});
+        } else if (settings.destinationId) {
+            return _lookupByNodeIdentifier(settings.destinationId, timeoutMs);
+        } else {
+            return rx.Observable.return({
+                destination16: settings.destination16,
+                destination64: settings.destination64
+            });
+        }
+    }
+
+
+    // Sends a the given command and parameter to the given destination.
+    // A stream is returned that will emit to the resulting command data
+    // on success or end in an Error with the failed status as the text.
+    // Only one of destination64 or destination16 should be given; the
+    // other should be undefined.
+    function _remoteCommand(command, destination64, destination16, timeoutMs, commandParameter, broadcast) {
+        var frame = {
+                type: xbee_api.constants.FRAME_TYPE.REMOTE_AT_COMMAND_REQUEST,
+                command: command,
+                commandParameter: commandParameter,
+                destination64: destination64,
+                destination16: destination16
+            },
+            responseStream;
+
+        if (debug) {
+            console.log("Sending", command, "to", destination64, "with parameter", commandParameter || []);
+        }
+
+        responseStream = _sendFrameStreamResponse(frame, timeoutMs, xbee_api.constants.FRAME_TYPE.REMOTE_COMMAND_RESPONSE)
+            .map(function (frame) {
+                if (frame.commandStatus === xbee_api.constants.COMMAND_STATUS.OK) {
+                    return frame.commandData;
+                }
+
+                // if not OK, throw error
+                throw new Error(xbee_api.constants.COMMAND_STATUS[frame.commandStatus]);
+            });
+
+        if (broadcast) {
+            return responseStream;
+        } else {
+            return responseStream.take(1);
+        }
+    }
+
+
+    // Sends a the given data to the given destination.  A stream is
+    // returned that will complete on success or end in an Error with the
+    // failed status as the text.  Only one of destination64 or
+    // destination16 should be given; the other should be undefined.
+    function _remoteTransmit(destination64, destination16, data, timeoutMs, broadcast) {
+        var frame = {
+                data: data,
+                type: xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_REQUEST,
+                destination64: destination64,
+                destination16: destination16
+            },
+            responseFrameType = xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS,
+            responseStream;
+
+        if (module === "802.15.4") {
+            responseFrameType = xbee_api.constants.FRAME_TYPE.TX_STATUS;
+            frame.type = destination64 ?
+                    xbee_api.constants.FRAME_TYPE.TX_REQUEST_64 :
+                    xbee_api.constants.FRAME_TYPE.TX_REQUEST_16;
+        }
+
+        if (debug) {
+            console.log("Sending '" + data + "' to", destination64 || destination16);
+        }
+
+        responseStream = _sendFrameStreamResponse(frame, timeoutMs, responseFrameType)
+            .flatMap(function (frame) {
+                if (frame.deliveryStatus === xbee_api.constants.DELIVERY_STATUS.SUCCESS) {
+                    return rx.Observable.empty();
+                }
+
+                // if not OK, throw error
+                return rx.Observable.throw(new Error(xbee_api.constants.DELIVERY_STATUS[frame.deliveryStatus]));
+            });
+
+        if (broadcast) {
+            return responseStream;
+        } else {
+            return responseStream.take(1);
         }
     }
 
@@ -353,24 +402,16 @@ module.exports = function xbeeRxLibrary(options) {
             }
         });
 
-        _validateDestination(settings);
-
         _validateCommand(settings.command);
 
         command = settings.command;
 
         commandParameter = settings.commandParameter || [];
 
-        if (settings.destination64 || settings.destination16) {
-            return _remoteCommand(command, settings.destination64, settings.destination16, timeoutMs, commandParameter);
-        }
-
-        if (settings.destinationId) {
-            return _lookupByNodeIdentifier(settings.destinationId, timeoutMs)
-                .flatMap(function (lookupResult) {
-                    return _remoteCommand(command, lookupResult, undefined, timeoutMs, commandParameter);
-                });
-        }
+        return _generateDestination(settings, timeoutMs)
+            .flatMap(function (destination) {
+                return _remoteCommand(command, destination.destination64, destination.destination16, timeoutMs, commandParameter, !!settings.broadcast);
+            });
     }
 
 
@@ -396,20 +437,12 @@ module.exports = function xbeeRxLibrary(options) {
             }
         });
 
-        _validateDestination(settings);
-
         data = settings.data;
 
-        if (settings.destination64 || settings.destination16) {
-            return _remoteTransmit(settings.destination64, settings.destination16, data, timeoutMs);
-        }
-
-        if (settings.destinationId) {
-            return _lookupByNodeIdentifier(settings.destinationId, timeoutMs)
-                .flatMap(function (lookupResult) {
-                    return _remoteTransmit(lookupResult, undefined, data, timeoutMs);
-                });
-        }
+        return _generateDestination(settings, timeoutMs)
+            .flatMap(function (destination) {
+                return _remoteTransmit(destination.destination64, destination.destination16, data, timeoutMs, !!settings.broadcast);
+            });
     }
 
 

--- a/lib/xbee-rx.js
+++ b/lib/xbee-rx.js
@@ -346,15 +346,15 @@ module.exports = function xbeeRxLibrary(options) {
         }
 
         return _sendFrameStreamResponse(frame, timeoutMs, responseFrameType)
+            .take(1)
             .flatMap(function (frame) {
                 if (frame.deliveryStatus === xbee_api.constants.DELIVERY_STATUS.SUCCESS) {
-                    return rx.Observable.empty();
+                    return rx.Observable.of(true);
                 }
 
                 // if not OK, throw error
                 return rx.Observable.throw(new Error(xbee_api.constants.DELIVERY_STATUS[frame.deliveryStatus]));
-            })
-            .take(1);
+            });
     }
 
 

--- a/lib/xbee-rx.js
+++ b/lib/xbee-rx.js
@@ -302,18 +302,20 @@ module.exports = function xbeeRxLibrary(options) {
         }
 
         responseStream = _sendFrameStreamResponse(frame, timeoutMs, xbee_api.constants.FRAME_TYPE.REMOTE_COMMAND_RESPONSE)
-            .map(function (frame) {
-                if (frame.commandStatus === xbee_api.constants.COMMAND_STATUS.OK) {
-                    return frame.commandData;
+            .flatMap(function (frame) {
+                if (frame.commandStatus === xbee_api.constants.COMMAND_STATUS.REMOTE_CMD_TRANS_FAILURE) {
+                    // if there was a remote command transmission failure, throw error
+                    rx.Observable.throw(new Error(xbee_api.constants.COMMAND_STATUS[frame.commandStatus]));
                 }
 
-                // if not OK, throw error
-                throw new Error(xbee_api.constants.COMMAND_STATUS[frame.commandStatus]);
+                // any other response is returned
+                return rx.Observable.return(frame);
             });
 
         if (broadcast) {
             return responseStream;
         } else {
+            // if not broadcast, there can be only one response packet
             return responseStream.take(1);
         }
     }

--- a/lib/xbee-rx.js
+++ b/lib/xbee-rx.js
@@ -323,15 +323,14 @@ module.exports = function xbeeRxLibrary(options) {
     // returned that will complete on success or end in an Error with the
     // failed status as the text.  Only one of destination64 or
     // destination16 should be given; the other should be undefined.
-    function _remoteTransmit(destination64, destination16, data, timeoutMs, broadcast) {
+    function _remoteTransmit(destination64, destination16, data, timeoutMs) {
         var frame = {
                 data: data,
                 type: xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_REQUEST,
                 destination64: destination64,
                 destination16: destination16
             },
-            responseFrameType = xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS,
-            responseStream;
+            responseFrameType = xbee_api.constants.FRAME_TYPE.ZIGBEE_TRANSMIT_STATUS;
 
         if (module === "802.15.4") {
             responseFrameType = xbee_api.constants.FRAME_TYPE.TX_STATUS;
@@ -344,7 +343,7 @@ module.exports = function xbeeRxLibrary(options) {
             console.log("Sending '" + data + "' to", destination64 || destination16);
         }
 
-        responseStream = _sendFrameStreamResponse(frame, timeoutMs, responseFrameType)
+        return _sendFrameStreamResponse(frame, timeoutMs, responseFrameType)
             .flatMap(function (frame) {
                 if (frame.deliveryStatus === xbee_api.constants.DELIVERY_STATUS.SUCCESS) {
                     return rx.Observable.empty();
@@ -352,13 +351,8 @@ module.exports = function xbeeRxLibrary(options) {
 
                 // if not OK, throw error
                 return rx.Observable.throw(new Error(xbee_api.constants.DELIVERY_STATUS[frame.deliveryStatus]));
-            });
-
-        if (broadcast) {
-            return responseStream;
-        } else {
-            return responseStream.take(1);
-        }
+            })
+            .take(1);
     }
 
 
@@ -441,7 +435,7 @@ module.exports = function xbeeRxLibrary(options) {
 
         return _generateDestination(settings, timeoutMs)
             .flatMap(function (destination) {
-                return _remoteTransmit(destination.destination64, destination.destination16, data, timeoutMs, !!settings.broadcast);
+                return _remoteTransmit(destination.destination64, destination.destination16, data, timeoutMs);
             });
     }
 

--- a/lib/xbee-rx.js
+++ b/lib/xbee-rx.js
@@ -305,7 +305,7 @@ module.exports = function xbeeRxLibrary(options) {
             .flatMap(function (frame) {
                 if (frame.commandStatus === xbee_api.constants.COMMAND_STATUS.REMOTE_CMD_TRANS_FAILURE) {
                     // if there was a remote command transmission failure, throw error
-                    rx.Observable.throw(new Error(xbee_api.constants.COMMAND_STATUS[frame.commandStatus]));
+                    return rx.Observable.throw(new Error(xbee_api.constants.COMMAND_STATUS[frame.commandStatus]));
                 }
 
                 // any other response is returned

--- a/test/localCommand-tests.js
+++ b/test/localCommand-tests.js
@@ -197,20 +197,18 @@ describe("xbee-rx", function () {
 
                         it("does not emit data, complete or error", function (done) {
 
-                            var areDone = false;
+                            var subscription;
 
                             setTimeout(function () {
-                                areDone = true;
+                                subscription.dispose();
                                 done();
                             }, 50);
 
-                            commandResultStream
+                            subscription = commandResultStream
                                 .subscribe(function () {
                                     assert.fail("Stream contained data");
                                 }, function () {
-                                    if (!areDone) {
-                                        assert.fail("Stream ended with error early");
-                                    }
+                                    assert.fail("Stream ended with error");
                                 }, function () {
                                     assert.fail("Stream completed");
                                 });
@@ -234,20 +232,18 @@ describe("xbee-rx", function () {
 
                         it("does not emit data, complete or error", function (done) {
 
-                            var areDone = false;
+                            var subscription;
 
                             setTimeout(function () {
-                                areDone = true;
+                                subscription.dispose();
                                 done();
                             }, 50);
 
-                            commandResultStream
+                            subscription = commandResultStream
                                 .subscribe(function () {
                                     assert.fail("Stream contained data");
                                 }, function () {
-                                    if (!areDone) {
-                                        assert.fail("Stream ended with error early");
-                                    }
+                                    assert.fail("Stream ended with error");
                                 }, function () {
                                     assert.fail("Stream completed");
                                 });
@@ -314,3 +310,4 @@ describe("xbee-rx", function () {
     });
 
 });
+

--- a/test/remoteCommand-tests.js
+++ b/test/remoteCommand-tests.js
@@ -330,17 +330,20 @@ describe("xbee-rx", function () {
                             mockXbeeApi.emitFrame({
                                 type: mockXbeeApi.constants.FRAME_TYPE.REMOTE_COMMAND_RESPONSE,
                                 id: mockXbeeApi.lastFrameId,
-                                commandStatus: 0,
+                                commandStatus: mockXbeeApi.constants.COMMAND_STATUS.OK,
                                 commandData: [ 42, 16 ]
                             });
 
                         });
 
-                        it("emits 'commandData'", function (done) {
+                        it("emits whole packet", function (done) {
 
                             commandResultStream
                                 .subscribe(function (result) {
-                                    result.should.eql([ 42, 16 ]);
+                                    result.should.be.type("object");
+                                    result.should.have.property("type", mockXbeeApi.constants.FRAME_TYPE.REMOTE_COMMAND_RESPONSE);
+                                    result.should.have.property("commandStatus", mockXbeeApi.constants.COMMAND_STATUS.OK);
+                                    result.should.have.property("commandData", [ 42, 16 ]);
                                 }, function () {
                                     assert.fail("Stream ended with error");
                                 }, function () {
@@ -421,14 +424,14 @@ describe("xbee-rx", function () {
 
                     });
 
-                    describe("with failure response frame", function () {
+                    describe("with transmit failure response frame", function () {
 
                         beforeEach(function () {
 
                             mockXbeeApi.emitFrame({
                                 type: mockXbeeApi.constants.FRAME_TYPE.REMOTE_COMMAND_RESPONSE,
                                 id: mockXbeeApi.lastFrameId,
-                                commandStatus: 2,
+                                commandStatus: mockXbeeApi.constants.COMMAND_STATUS.REMOTE_CMD_TRANS_FAILURE,
                                 commandData: []
                             });
 
@@ -516,17 +519,20 @@ describe("xbee-rx", function () {
                             mockXbeeApi.emitFrame({
                                 type: mockXbeeApi.constants.FRAME_TYPE.REMOTE_COMMAND_RESPONSE,
                                 id: mockXbeeApi.lastFrameId,
-                                commandStatus: 0,
-                                commandData: []
+                                commandStatus: mockXbeeApi.constants.COMMAND_STATUS.ERROR,
+                                commandData: undefined
                             });
 
                         });
 
-                        it("emits 'commandData'", function (done) {
+                        it("emits whole packet", function (done) {
 
                             commandResultStream
                                 .subscribe(function (result) {
-                                    result.should.eql([]);
+                                    result.should.be.type("object");
+                                    result.should.have.property("type", mockXbeeApi.constants.FRAME_TYPE.REMOTE_COMMAND_RESPONSE);
+                                    result.should.have.property("commandStatus", mockXbeeApi.constants.COMMAND_STATUS.ERROR);
+                                    result.should.have.property("commandData", undefined);
                                 }, function () {
                                     assert.fail("Stream ended with error");
                                 }, function () {
@@ -607,14 +613,14 @@ describe("xbee-rx", function () {
 
                     });
 
-                    describe("with failure response frame", function () {
+                    describe("with transmit failure response frame", function () {
 
                         beforeEach(function () {
 
                             mockXbeeApi.emitFrame({
                                 type: mockXbeeApi.constants.FRAME_TYPE.REMOTE_COMMAND_RESPONSE,
                                 id: mockXbeeApi.lastFrameId,
-                                commandStatus: 1,
+                                commandStatus: mockXbeeApi.constants.COMMAND_STATUS.REMOTE_CMD_TRANS_FAILURE,
                                 commandData: []
                             });
 
@@ -726,17 +732,20 @@ describe("xbee-rx", function () {
                                     mockXbeeApi.emitFrame({
                                         type: mockXbeeApi.constants.FRAME_TYPE.REMOTE_COMMAND_RESPONSE,
                                         id: mockXbeeApi.lastFrameId,
-                                        commandStatus: 0,
+                                        commandStatus: 42,
                                         commandData: [ 1, 2, 3, 4 ]
                                     });
 
                                 });
 
-                                it("emits 'commandData'", function (done) {
+                                it("emits whole packet", function (done) {
 
                                     commandResultStream
                                         .subscribe(function (result) {
-                                            result.should.eql([ 1, 2, 3, 4 ]);
+                                            result.should.be.type("object");
+                                            result.should.have.property("type", mockXbeeApi.constants.FRAME_TYPE.REMOTE_COMMAND_RESPONSE);
+                                            result.should.have.property("commandStatus", 42);
+                                            result.should.have.property("commandData", [ 1, 2, 3, 4 ]);
                                         }, function () {
                                             assert.fail("Stream ended with error");
                                         }, function () {
@@ -817,14 +826,14 @@ describe("xbee-rx", function () {
 
                             });
 
-                            describe("with failure remote command response frame", function () {
+                            describe("with transmit failure remote command response frame", function () {
 
                                 beforeEach(function () {
 
                                     mockXbeeApi.emitFrame({
                                         type: mockXbeeApi.constants.FRAME_TYPE.REMOTE_COMMAND_RESPONSE,
                                         id: mockXbeeApi.lastFrameId,
-                                        commandStatus: 1,
+                                        commandStatus: mockXbeeApi.constants.COMMAND_STATUS.REMOTE_CMD_TRANS_FAILURE,
                                         commandData: [ 1, 2, 3, 4 ]
                                     });
 
@@ -992,14 +1001,14 @@ describe("xbee-rx", function () {
 
                         });
 
-                        describe("with failure lookup response frame", function () {
+                        describe("with transmit failure lookup response frame", function () {
 
                             beforeEach(function () {
 
                                 mockXbeeApi.emitFrame({
                                     type: mockXbeeApi.constants.FRAME_TYPE.AT_COMMAND_RESPONSE,
                                     id: mockXbeeApi.lastFrameId,
-                                    commandStatus: 1,
+                                    commandStatus: mockXbeeApi.constants.COMMAND_STATUS.REMOTE_CMD_TRANS_FAILURE,
                                     commandData: [ ]
                                 });
 

--- a/test/remoteCommand-tests.js
+++ b/test/remoteCommand-tests.js
@@ -366,20 +366,18 @@ describe("xbee-rx", function () {
 
                         it("does not emit data, complete or error", function (done) {
 
-                            var areDone = false;
+                            var subscription;
 
                             setTimeout(function () {
-                                areDone = true;
+                                subscription.dispose();
                                 done();
                             }, 50);
 
-                            commandResultStream
+                            subscription = commandResultStream
                                 .subscribe(function () {
                                     assert.fail("Stream contained data");
                                 }, function () {
-                                    if (!areDone) {
-                                        assert.fail("Stream ended with error early");
-                                    }
+                                    assert.fail("Stream ended with error");
                                 }, function () {
                                     assert.fail("Stream completed");
                                 });
@@ -403,20 +401,18 @@ describe("xbee-rx", function () {
 
                         it("does not emit data, complete or error", function (done) {
 
-                            var areDone = false;
+                            var subscription;
 
                             setTimeout(function () {
-                                areDone = true;
+                                subscription.dispose();
                                 done();
                             }, 50);
 
-                            commandResultStream
+                            subscription = commandResultStream
                                 .subscribe(function () {
                                     assert.fail("Stream contained data");
                                 }, function () {
-                                    if (!areDone) {
-                                        assert.fail("Stream ended with error early");
-                                    }
+                                    assert.fail("Stream ended with error");
                                 }, function () {
                                     assert.fail("Stream completed");
                                 });
@@ -556,20 +552,18 @@ describe("xbee-rx", function () {
 
                         it("does not emit data, complete or error", function (done) {
 
-                            var areDone = false;
+                            var subscription;
 
                             setTimeout(function () {
-                                areDone = true;
+                                subscription.dispose();
                                 done();
                             }, 50);
 
-                            commandResultStream
+                            subscription = commandResultStream
                                 .subscribe(function () {
                                     assert.fail("Stream contained data");
                                 }, function () {
-                                    if (!areDone) {
-                                        assert.fail("Stream ended with error early");
-                                    }
+                                    assert.fail("Stream ended with error");
                                 }, function () {
                                     assert.fail("Stream completed");
                                 });
@@ -593,20 +587,18 @@ describe("xbee-rx", function () {
 
                         it("does not emit data, complete or error", function (done) {
 
-                            var areDone = false;
+                            var subscription;
 
                             setTimeout(function () {
-                                areDone = true;
+                                subscription.dispose();
                                 done();
                             }, 50);
 
-                            commandResultStream
+                            subscription = commandResultStream
                                 .subscribe(function () {
                                     assert.fail("Stream contained data");
                                 }, function () {
-                                    if (!areDone) {
-                                        assert.fail("Stream ended with error early");
-                                    }
+                                    assert.fail("Stream ended with error");
                                 }, function () {
                                     assert.fail("Stream completed");
                                 });
@@ -770,20 +762,18 @@ describe("xbee-rx", function () {
 
                                 it("does not emit data, complete or error", function (done) {
 
-                                    var areDone = false;
+                                    var subscription;
 
                                     setTimeout(function () {
-                                        areDone = true;
+                                        subscription.dispose();
                                         done();
                                     }, 50);
 
-                                    commandResultStream
+                                    subscription = commandResultStream
                                         .subscribe(function () {
                                             assert.fail("Stream contained data");
                                         }, function () {
-                                            if (!areDone) {
-                                                assert.fail("Stream ended with error early");
-                                            }
+                                            assert.fail("Stream ended with error");
                                         }, function () {
                                             assert.fail("Stream completed");
                                         });
@@ -807,20 +797,18 @@ describe("xbee-rx", function () {
 
                                 it("does not emit data, complete or error", function (done) {
 
-                                    var areDone = false;
+                                    var subscription;
 
                                     setTimeout(function () {
-                                        areDone = true;
+                                        subscription.dispose();
                                         done();
                                     }, 50);
 
-                                    commandResultStream
+                                    subscription = commandResultStream
                                         .subscribe(function () {
                                             assert.fail("Stream contained data");
                                         }, function () {
-                                            if (!areDone) {
-                                                assert.fail("Stream ended with error early");
-                                            }
+                                            assert.fail("Stream ended with error");
                                         }, function () {
                                             assert.fail("Stream completed");
                                         });
@@ -949,20 +937,18 @@ describe("xbee-rx", function () {
 
                             it("does not emit data, complete or error", function (done) {
 
-                                var areDone = false;
+                                var subscription;
 
                                 setTimeout(function () {
-                                    areDone = true;
+                                    subscription.dispose();
                                     done();
                                 }, 50);
 
-                                commandResultStream
+                                subscription = commandResultStream
                                     .subscribe(function () {
                                         assert.fail("Stream contained data");
                                     }, function () {
-                                        if (!areDone) {
-                                            assert.fail("Stream ended with error early");
-                                        }
+                                        assert.fail("Stream ended with error");
                                     }, function () {
                                         assert.fail("Stream completed");
                                     });
@@ -986,20 +972,18 @@ describe("xbee-rx", function () {
 
                             it("does not emit data, complete or error", function (done) {
 
-                                var areDone = false;
+                                var subscription;
 
                                 setTimeout(function () {
-                                    areDone = true;
+                                    subscription.dispose();
                                     done();
                                 }, 50);
 
-                                commandResultStream
+                                subscription = commandResultStream
                                     .subscribe(function () {
                                         assert.fail("Stream contained data");
                                     }, function () {
-                                        if (!areDone) {
-                                            assert.fail("Stream ended with error early");
-                                        }
+                                        assert.fail("Stream ended with error");
                                     }, function () {
                                         assert.fail("Stream completed");
                                     });

--- a/test/remoteCommand-tests.js
+++ b/test/remoteCommand-tests.js
@@ -119,7 +119,7 @@ describe("xbee-rx", function () {
                         ];
 
                     badSettings.forEach(function (settings) {
-                        callRemoteCommand(settings).should.throw(/one of these properties must be used: 'destinationId,destination64,destination16'/);
+                        callRemoteCommand(settings).should.throw(/'destination16', 'destination64', or 'broadcast = true' must be specified./);
                     });
 
                 });

--- a/test/remoteTransmit-tests.js
+++ b/test/remoteTransmit-tests.js
@@ -341,20 +341,18 @@ describe("xbee-rx", function () {
 
                         it("does not emit data, complete or error", function (done) {
 
-                            var areDone = false;
+                            var subscription;
 
                             setTimeout(function () {
-                                areDone = true;
+                                subscription.dispose();
                                 done();
                             }, 50);
 
-                            commandResultStream
+                            subscription = commandResultStream
                                 .subscribe(function () {
                                     assert.fail("Stream contained data");
                                 }, function () {
-                                    if (!areDone) {
-                                        assert.fail("Stream ended with error early");
-                                    }
+                                    assert.fail("Stream ended with error");
                                 }, function () {
                                     assert.fail("Stream completed");
                                 });
@@ -379,24 +377,21 @@ describe("xbee-rx", function () {
 
                         it("does not emit data, complete or error", function (done) {
 
-                            var areDone = false;
+                            var subscription;
 
                             setTimeout(function () {
-                                areDone = true;
+                                subscription.dispose();
                                 done();
                             }, 50);
 
-                            commandResultStream
+                            subscription = commandResultStream
                                 .subscribe(function () {
                                     assert.fail("Stream contained data");
                                 }, function () {
-                                    if (!areDone) {
-                                        assert.fail("Stream ended with error early");
-                                    }
+                                    assert.fail("Stream ended with error");
                                 }, function () {
                                     assert.fail("Stream completed");
                                 });
-
                         });
 
                     });
@@ -536,20 +531,18 @@ describe("xbee-rx", function () {
 
                         it("does not emit data, complete or error", function (done) {
 
-                            var areDone = false;
+                            var subscription;
 
                             setTimeout(function () {
-                                areDone = true;
+                                subscription.dispose();
                                 done();
                             }, 50);
 
-                            commandResultStream
+                            subscription = commandResultStream
                                 .subscribe(function () {
                                     assert.fail("Stream contained data");
                                 }, function () {
-                                    if (!areDone) {
-                                        assert.fail("Stream ended with error early");
-                                    }
+                                    assert.fail("Stream ended with error");
                                 }, function () {
                                     assert.fail("Stream completed");
                                 });
@@ -574,20 +567,18 @@ describe("xbee-rx", function () {
 
                         it("does not emit data, complete or error", function (done) {
 
-                            var areDone = false;
+                            var subscription;
 
                             setTimeout(function () {
-                                areDone = true;
+                                subscription.dispose();
                                 done();
                             }, 50);
 
-                            commandResultStream
+                            subscription = commandResultStream
                                 .subscribe(function () {
                                     assert.fail("Stream contained data");
                                 }, function () {
-                                    if (!areDone) {
-                                        assert.fail("Stream ended with error early");
-                                    }
+                                    assert.fail("Stream ended with error");
                                 }, function () {
                                     assert.fail("Stream completed");
                                 });
@@ -757,20 +748,18 @@ describe("xbee-rx", function () {
 
                                 it("does not emit data, complete or error", function (done) {
 
-                                    var areDone = false;
+                                    var subscription;
 
                                     setTimeout(function () {
-                                        areDone = true;
+                                        subscription.dispose();
                                         done();
                                     }, 50);
 
-                                    commandResultStream
+                                    subscription = commandResultStream
                                         .subscribe(function () {
                                             assert.fail("Stream contained data");
                                         }, function () {
-                                            if (!areDone) {
-                                                assert.fail("Stream ended with error early");
-                                            }
+                                            assert.fail("Stream ended with error");
                                         }, function () {
                                             assert.fail("Stream completed");
                                         });
@@ -795,20 +784,18 @@ describe("xbee-rx", function () {
 
                                 it("does not emit data, complete or error", function (done) {
 
-                                    var areDone = false;
+                                    var subscription;
 
                                     setTimeout(function () {
-                                        areDone = true;
+                                        subscription.dispose();
                                         done();
                                     }, 50);
 
-                                    commandResultStream
+                                    subscription = commandResultStream
                                         .subscribe(function () {
                                             assert.fail("Stream contained data");
                                         }, function () {
-                                            if (!areDone) {
-                                                assert.fail("Stream ended with error early");
-                                            }
+                                            assert.fail("Stream ended with error");
                                         }, function () {
                                             assert.fail("Stream completed");
                                         });
@@ -941,20 +928,18 @@ describe("xbee-rx", function () {
 
                             it("does not emit data, complete or error", function (done) {
 
-                                var areDone = false;
+                                var subscription;
 
                                 setTimeout(function () {
-                                    areDone = true;
+                                    subscription.dispose();
                                     done();
                                 }, 50);
 
-                                commandResultStream
+                                subscription = commandResultStream
                                     .subscribe(function () {
                                         assert.fail("Stream contained data");
                                     }, function () {
-                                        if (!areDone) {
-                                            assert.fail("Stream ended with error early");
-                                        }
+                                        assert.fail("Stream ended with error");
                                     }, function () {
                                         assert.fail("Stream completed");
                                     });
@@ -978,20 +963,18 @@ describe("xbee-rx", function () {
 
                             it("does not emit data, complete or error", function (done) {
 
-                                var areDone = false;
+                                var subscription;
 
                                 setTimeout(function () {
-                                    areDone = true;
+                                    subscription.dispose();
                                     done();
                                 }, 50);
 
-                                commandResultStream
+                                subscription = commandResultStream
                                     .subscribe(function () {
                                         assert.fail("Stream contained data");
                                     }, function () {
-                                        if (!areDone) {
-                                            assert.fail("Stream ended with error early");
-                                        }
+                                        assert.fail("Stream ended with error");
                                     }, function () {
                                         assert.fail("Stream completed");
                                     });

--- a/test/remoteTransmit-tests.js
+++ b/test/remoteTransmit-tests.js
@@ -310,11 +310,11 @@ describe("xbee-rx", function () {
 
                         });
 
-                        it("completes without any value", function (done) {
+                        it("emits 'true'", function (done) {
 
                             commandResultStream
-                                .subscribe(function () {
-                                    assert.fail("Stream emitted something");
+                                .subscribe(function (result) {
+                                    result.should.equal(true);
                                 }, function () {
                                     assert.fail("Stream ended with error");
                                 }, function () {

--- a/test/remoteTransmit-tests.js
+++ b/test/remoteTransmit-tests.js
@@ -93,7 +93,7 @@ describe("xbee-rx", function () {
                         ];
 
                     badSettings.forEach(function (settings) {
-                        callRemoteTransmit(settings).should.throw(/one of these properties must be used: 'destinationId,destination64,destination16'/);
+                        callRemoteTransmit(settings).should.throw(/'destination16', 'destination64', or 'broadcast = true' must be specified./);
                     });
 
                 });


### PR DESCRIPTION
This adds broadcast support to the remote command and remote transmit options.

Since a remote command could return multiple packets (one from each node that receives the command), the remote command stream now can return multiple results.  In addition, since the node that replied might be needed, the whole frame is now included in the stream.

Since this has API changes, this will be released as `v3.0.0`.

Closes #6